### PR TITLE
Enhancements to Fhir Schema Converter

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,3 @@
-import Dependencies._
-
 ThisBuild / scalaVersion     := "2.12.8"
 ThisBuild / version          := "0.1.0-SNAPSHOT"
 ThisBuild / organization     := "com.example"
@@ -7,9 +5,10 @@ ThisBuild / organizationName := "example"
 
 lazy val root = (project in file("."))
   .settings(
-    name := "FhirSchemaConverter",
-    libraryDependencies += scalaTest % Test
+    name := "FhirSchemaConverter"
   )
+libraryDependencies += "org.scalactic" %% "scalactic" % "3.0.8"
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.8" % "test"
 libraryDependencies += "com.typesafe.play" %% "play-json" % "2.7.2"
 libraryDependencies += "org.postgresql" % "postgresql" % "42.2.5"
 libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.2.3"

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1,5 +1,6 @@
 output.db.host=localhost
 output.db.port=5432
-output.db.database=fhirbase
+output.db.database="fhirbase"
+output.db.schema="kainos_kingdom_integration1"
 output.db.username=postgres
 output.db.password=postgres

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1,6 +1,6 @@
 output.db.host=localhost
 output.db.port=5432
 output.db.database="fhirbase"
-output.db.schema="kainos_kingdom_integration1"
+output.db.schema=""  //kainos_kingdom_integration1
 output.db.username=postgres
 output.db.password=postgres

--- a/src/main/scala/com/kainos/fhirschemaconverter/FhirSchemaConverter.scala
+++ b/src/main/scala/com/kainos/fhirschemaconverter/FhirSchemaConverter.scala
@@ -11,7 +11,23 @@ import play.api.libs.json.JsValue
   */
 object FhirSchemaConverter extends App {
 
-  val jsonSchema: JsValue = FhirSchemaReader.read()
-  val fhirResources = JsonToFhirResource.convert(jsonSchema)
-  SqlWriter.createSqlViews(fhirResources)
+  //Hard coded way of swiching bewteen a file based schema and the FHIR StructureDefiniton schema.
+  val fhirSchemaFromFile: Boolean = true;
+
+  if (fhirSchemaFromFile) { 
+    val jsonSchema: JsValue = FhirSchemaReader.read()
+    val fhirResources = JsonToFhirResource.convert(jsonSchema)
+    SqlWriter.createSqlViews(fhirResources)
+  }
+  else { 
+    //Tables of interest to Evolve IC reporting project
+    val tableList = List("Patient","Encounter","Observation", "MedicationOrder");
+
+    for( table <- tableList){ 
+      println("Processing Table is : " +table); 
+      var fhirResources = JsonToFhirResource.convertFromDB(FhirSchemaReader.loadStructureDefinition(table))
+      SqlWriter.createSqlViews(fhirResources)
+    } 
+  }
+
 }

--- a/src/main/scala/com/kainos/fhirschemaconverter/FhirSchemaConverter.scala
+++ b/src/main/scala/com/kainos/fhirschemaconverter/FhirSchemaConverter.scala
@@ -11,7 +11,9 @@ import play.api.libs.json.JsValue
   */
 object FhirSchemaConverter extends App {
 
-  //Hard coded way of swiching bewteen a file based schema and the FHIR StructureDefiniton schema.
+  //Hard coded boolean for swiching bewteen a file based schema and the FHIR StructureDefiniton schema.
+  //Note: the fhir_base:latest docker image does not have any data in the (public) StructureDefiniton table.
+  //so this will need an Evolve IC database to run.
   val fhirSchemaFromFile: Boolean = true;
 
   if (fhirSchemaFromFile) { 
@@ -24,7 +26,7 @@ object FhirSchemaConverter extends App {
     val tableList = List("Patient","Encounter","Observation", "MedicationOrder");
 
     for( table <- tableList){ 
-      println("Processing Table is : " +table); 
+      println("Processing table : " +table); 
       var fhirResources = JsonToFhirResource.convertFromDB(FhirSchemaReader.loadStructureDefinition(table))
       SqlWriter.createSqlViews(fhirResources)
     } 

--- a/src/main/scala/com/kainos/fhirschemaconverter/json/converter/JsonToDataType.scala
+++ b/src/main/scala/com/kainos/fhirschemaconverter/json/converter/JsonToDataType.scala
@@ -11,8 +11,27 @@ object JsonToDataType extends StrictLogging {
 
   def convert(property: JsValue) = {
 
+/*
     val dataTypeFromJson = (property \ "type" \ 0 \ "code")
-    if ((property \ "base" \ "max").as[String].equals("*")) {
+    //if ((property \ "base" \ "max").as[String].equals("*")) {
+    //  ArrayType
+    //}
+    //else 
+    if (dataTypeFromJson.isDefined) {
+      dataTypeFromJson.as[String] match {
+        case "dateTime" | "instant" => DateType
+        case "decimal" => DoubleType
+        case "Quantity" => ObjectType
+        case _ => StringType
+      }
+    }
+    //else StringType
+    else ArrayType
+*/
+    val dataTypeFromJson = (property \ "type" \ 0 \ "code")
+    val baseMaxFromJson = (property \ "base" \ "max")
+
+    if (baseMaxFromJson.isDefined &&  baseMaxFromJson.as[String].equals("*")) {
       ArrayType
     }
     else if (dataTypeFromJson.isDefined) {
@@ -24,6 +43,7 @@ object JsonToDataType extends StrictLogging {
       }
     }
     else StringType
+    
   }
 
 }

--- a/src/main/scala/com/kainos/fhirschemaconverter/json/converter/JsonToDataType.scala
+++ b/src/main/scala/com/kainos/fhirschemaconverter/json/converter/JsonToDataType.scala
@@ -10,28 +10,13 @@ import play.api.libs.json.JsValue
 object JsonToDataType extends StrictLogging {
 
   def convert(property: JsValue) = {
-
-/*
     val dataTypeFromJson = (property \ "type" \ 0 \ "code")
-    //if ((property \ "base" \ "max").as[String].equals("*")) {
-    //  ArrayType
-    //}
-    //else 
-    if (dataTypeFromJson.isDefined) {
-      dataTypeFromJson.as[String] match {
-        case "dateTime" | "instant" => DateType
-        case "decimal" => DoubleType
-        case "Quantity" => ObjectType
-        case _ => StringType
-      }
-    }
-    //else StringType
-    else ArrayType
-*/
-    val dataTypeFromJson = (property \ "type" \ 0 \ "code")
-    val baseMaxFromJson = (property \ "base" \ "max")
+    val maxFromJson = (property \ "max")
 
-    if (baseMaxFromJson.isDefined &&  baseMaxFromJson.as[String].equals("*")) {
+     //logger.debug("dataTypeFromJson: " + dataTypeFromJson.toString())
+     //logger.debug("maxFromJson: " + maxFromJson.toString())
+
+    if (maxFromJson.isDefined &&  maxFromJson.as[String].equals("*")) {
       ArrayType
     }
     else if (dataTypeFromJson.isDefined) {

--- a/src/main/scala/com/kainos/fhirschemaconverter/json/converter/JsonToFhirResource.scala
+++ b/src/main/scala/com/kainos/fhirschemaconverter/json/converter/JsonToFhirResource.scala
@@ -10,6 +10,9 @@ import play.api.libs.json.{JsArray, JsValue}
 object JsonToFhirResource extends StrictLogging {
 
   def convert(jsonSchema: JsValue): Set[FhirResource] = {
+
+    logger.debug("Entry into JsonToFhirResource.convert")
+
     val resources: JsArray = (jsonSchema \ "entry").asOpt[JsArray].get
 
     resources.value
@@ -19,7 +22,13 @@ object JsonToFhirResource extends StrictLogging {
       logger.debug(s"Resource name: $resourceId")
 
       val properties: JsArray = (resource \ "resource" \ "snapshot" \ "element").asOpt[JsArray].get
+
+      //logger.debug(properties.toString())
+
       val fhirResourceProperties = properties.value.map(property => {
+
+       // logger.debug(property.toString())
+        
         JsonToFhirProperty.convert(property)
       }).toSet
 

--- a/src/main/scala/com/kainos/fhirschemaconverter/json/converter/JsonToFhirResource.scala
+++ b/src/main/scala/com/kainos/fhirschemaconverter/json/converter/JsonToFhirResource.scala
@@ -2,7 +2,7 @@ package com.kainos.fhirschemaconverter.json.converter
 
 import com.kainos.fhirschemaconverter.model._
 import com.typesafe.scalalogging.StrictLogging
-import play.api.libs.json.{JsArray, JsValue}
+import play.api.libs.json.{JsArray, JsValue, JsObject, Json}
 
 /**
   * Converts json schema resource to internal representation that's used for further processing
@@ -23,8 +23,6 @@ object JsonToFhirResource extends StrictLogging {
 
       val properties: JsArray = (resource \ "resource" \ "snapshot" \ "element").asOpt[JsArray].get
 
-      //logger.debug(properties.toString())
-
       val fhirResourceProperties = properties.value.map(property => {
 
        // logger.debug(property.toString())
@@ -43,6 +41,36 @@ object JsonToFhirResource extends StrictLogging {
 
       FhirResource(resourceId, resourceType, fhirResourcePropertiesWithArraySelection)
     }).toSet
+  }
+
+  def convertFromDB (jsonSchema: JsValue): Set[FhirResource] = {
+
+    logger.debug("Entry into JsonToFhirResource.convertFromDB")
+
+    //logger.debug(jsonSchema.toString())
+
+    val resourceId = (jsonSchema \ "id").as[String]
+    val resourceType = (jsonSchema \ "type").as[String]
+
+      logger.debug(s"Resource name: $resourceId")
+      logger.debug(s"Resource type: $resourceType")
+
+      val properties: JsArray = (jsonSchema \ "snapshot" \ "element").asOpt[JsArray].get
+
+      val fhirResourceProperties = properties.value.map(property => {
+        JsonToFhirProperty.convert(property)
+      }).toSet
+
+      val arrayProperties = fhirResourceProperties.filter(r => r.dataType.equals(ArrayType))
+
+      val pathsOfArrayProperties: List[String] = arrayProperties.map(v =>
+        (v.columnNamesOfParentResources :+ v.name).mkString(".")).toList.sorted.reverse
+
+      val fhirResourcePropertiesWithArraySelection = fhirResourceProperties.map(r =>
+        FhirResourceProperty(r.name, r.dataType, getFirstArrayElementIfPresent(
+          pathsOfArrayProperties, r.columnNamesOfParentResources)))
+
+      Set(FhirResource(resourceId, resourceType, fhirResourcePropertiesWithArraySelection))
   }
 
   /**

--- a/src/main/scala/com/kainos/fhirschemaconverter/json/reader/FhirSchemaReader.scala
+++ b/src/main/scala/com/kainos/fhirschemaconverter/json/reader/FhirSchemaReader.scala
@@ -16,8 +16,6 @@ object FhirSchemaReader {
   // taken from file for simplicity 
   def read(): JsValue = {
     Json.parse(Source.fromResource("care-connect-schema-definition-full.json").getLines().mkString)
-
-     // Json.parse(Source.fromResource("care-connect-patient-colla.json").getLines().mkString)
   }
 
   // read from FHIR DB

--- a/src/main/scala/com/kainos/fhirschemaconverter/json/reader/FhirSchemaReader.scala
+++ b/src/main/scala/com/kainos/fhirschemaconverter/json/reader/FhirSchemaReader.scala
@@ -2,17 +2,34 @@ package com.kainos.fhirschemaconverter.json.reader
 
 import play.api.libs.json.{JsValue, Json}
 
+import java.sql.{Connection, DriverManager, ResultSet}
+import com.typesafe.scalalogging.StrictLogging
+import com.kainos.fhirschemaconverter.persistence.{SqlUtils,SqlReader}
+
 import scala.io.Source
 
 /**
-  * Definition of FHIR Schema. Currently taken from file for simplicity but could be read from DB or FHIR Rest API
+  * Definition of FHIR Schema. 
   */
 object FhirSchemaReader {
 
+  // taken from file for simplicity 
   def read(): JsValue = {
-    Json.parse(Source.fromResource("care-connect-schema-definition-full.json")
-    //Json.parse(Source.fromResource("patient.json")
-      .getLines().mkString)
+    Json.parse(Source.fromResource("care-connect-schema-definition-full.json").getLines().mkString)
+
+     // Json.parse(Source.fromResource("care-connect-patient-colla.json").getLines().mkString)
   }
 
+  // read from FHIR DB
+  def loadStructureDefinition(tableName: String): JsValue = {
+
+     val sqlConnection: Connection = SqlUtils.getSqlConnection()
+
+     var rs: ResultSet = SqlReader.fetchSchemaForTable (
+                                    tableName,
+                                    sqlConnection)
+
+    Json.parse(rs.getString("resource"))
+
+  }
 }

--- a/src/main/scala/com/kainos/fhirschemaconverter/json/reader/FhirSchemaReader.scala
+++ b/src/main/scala/com/kainos/fhirschemaconverter/json/reader/FhirSchemaReader.scala
@@ -11,6 +11,7 @@ object FhirSchemaReader {
 
   def read(): JsValue = {
     Json.parse(Source.fromResource("care-connect-schema-definition-full.json")
+    //Json.parse(Source.fromResource("patient.json")
       .getLines().mkString)
   }
 

--- a/src/main/scala/com/kainos/fhirschemaconverter/persistence/FhirPropertyToSqlColumn.scala
+++ b/src/main/scala/com/kainos/fhirschemaconverter/persistence/FhirPropertyToSqlColumn.scala
@@ -31,8 +31,23 @@ object FhirPropertyToSqlColumn {
 
   def generateUniqueColumnName(fhirColumn: FhirResourceProperty): String = {
     val hasParents = fhirColumn.columnNamesOfParentResources.nonEmpty
-    val colName = if (hasParents) fhirColumn.columnNamesOfParentResources.mkString("_") + "_" +
+    var colName = if (hasParents) fhirColumn.columnNamesOfParentResources.mkString("_") + "_" +
       fhirColumn.name else fhirColumn.name
-    colName.slice(0, 60) //postgres max length of column name is 62
+    
+    if (colName.length() > 62) {
+      // shorten column name by removing the _
+      colName = colName.replace("_","")
+
+      // if still too long truncate it.
+      if (colName.length() > 62) {
+            colName.slice(0, 61) //postgres max length of column name is 62
+      }
+      else {
+        colName
+      }
+    }
+    else {
+      colName
+    }
   }
 }

--- a/src/main/scala/com/kainos/fhirschemaconverter/persistence/FhirPropertyToSqlColumn.scala
+++ b/src/main/scala/com/kainos/fhirschemaconverter/persistence/FhirPropertyToSqlColumn.scala
@@ -11,14 +11,14 @@ object FhirPropertyToSqlColumn {
 
     val hasParents = fhirColumn.columnNamesOfParentResources.nonEmpty
     val parentSelector = if (hasParents) {
-      ("->'" + fhirColumn.columnNamesOfParentResources.mkString("'->'") + "' ->>'")
+      ("->'" + fhirColumn.columnNamesOfParentResources.mkString("'->'") + "'->>'")
         .replace(">'0'", ">0")
     } else "->>'"
     val asClause = "as " + generateUniqueColumnName(fhirColumn)
 
     if (fhirColumn.dataType.equals(ArrayType)) {
       "cast(a.resource" + parentSelector.replace("->>'", "->'") +
-        fhirColumn.name + "' as " + fhirColumn.dataType.sqlType + ")" + asClause
+        fhirColumn.name + "' as " + fhirColumn.dataType.sqlType + ") " + asClause
     }
     else if (!fhirColumn.dataType.equals(StringType)) {
       "cast(a.resource" + parentSelector + fhirColumn.name + "' as " +

--- a/src/main/scala/com/kainos/fhirschemaconverter/persistence/SqlReader.scala
+++ b/src/main/scala/com/kainos/fhirschemaconverter/persistence/SqlReader.scala
@@ -1,0 +1,33 @@
+package com.kainos.fhirschemaconverter.persistence
+
+import java.sql.{Connection, DriverManager, ResultSet}
+
+import com.kainos.fhirschemaconverter.model._
+import com.typesafe.config.ConfigFactory
+import com.typesafe.scalalogging.StrictLogging
+
+/**
+  * Creates views in database based on our internal collection of FHIR resources
+  */
+object SqlReader extends StrictLogging {
+
+   def fetchSchemaForTable (   //schema: String,
+                                    tableName: String,
+                                    sql_connection: Connection): ResultSet = {
+
+
+    //loaded from resources/application.conf if no overrides set in environment
+    val conf = ConfigFactory.load
+    var schema = conf.getString("output.db.schema")
+
+    val getStructureDefinition = s"select (resource - 'text')::text as resource from $schema.structuredefinition " + 
+                                 s"where id = '$tableName' "
+
+    logger.debug("SQL to getStructureDefinition: " + getStructureDefinition)
+
+    val statement = sql_connection.createStatement()
+    val resultSet: ResultSet = statement.executeQuery(getStructureDefinition)
+    resultSet.next()
+    resultSet
+  }
+}

--- a/src/main/scala/com/kainos/fhirschemaconverter/persistence/SqlReader.scala
+++ b/src/main/scala/com/kainos/fhirschemaconverter/persistence/SqlReader.scala
@@ -11,16 +11,20 @@ import com.typesafe.scalalogging.StrictLogging
   */
 object SqlReader extends StrictLogging {
 
-   def fetchSchemaForTable (   //schema: String,
-                                    tableName: String,
-                                    sql_connection: Connection): ResultSet = {
+   def fetchSchemaForTable (tableName: String,
+                            sql_connection: Connection): ResultSet = {
 
 
-    //loaded from resources/application.conf if no overrides set in environment
+    //Is a tenant schema set in application.conf
     val conf = ConfigFactory.load
     var schema = conf.getString("output.db.schema")
 
-    val getStructureDefinition = s"select (resource - 'text')::text as resource from $schema.structuredefinition " + 
+    if (schema.length() > 0) { 
+        schema = schema.concat(".")
+     }
+
+    val getStructureDefinition = s"select (resource - 'text')::text as resource from $schema" + 
+                                 s"structuredefinition " + 
                                  s"where id = '$tableName' "
 
     logger.debug("SQL to getStructureDefinition: " + getStructureDefinition)

--- a/src/main/scala/com/kainos/fhirschemaconverter/persistence/SqlUtils.scala
+++ b/src/main/scala/com/kainos/fhirschemaconverter/persistence/SqlUtils.scala
@@ -1,8 +1,10 @@
 package com.kainos.fhirschemaconverter.persistence
 
-import java.sql.Connection
+import java.sql.{Connection, DriverManager, ResultSet}
+import com.typesafe.config.ConfigFactory
+import com.typesafe.scalalogging.StrictLogging
 
-object SqlUtils {
+object SqlUtils extends StrictLogging {
 
   def tableExists(tableName: String, sqlConnection: Connection): Boolean = {
     val dbm = sqlConnection.getMetaData
@@ -12,4 +14,28 @@ object SqlUtils {
 
   def isAlphaNumeric(s: String) = s.forall((('a' to 'z') ++ ('A' to 'Z') ++ ('0' to '9'))
     .toSet.contains(_))
+
+  def getSqlConnection () : Connection  = { 
+    //loaded from resources/application.conf if no overrides set in environment
+    val conf = ConfigFactory.load
+    val hostname = conf.getString("output.db.host")
+    val port = conf.getString("output.db.port")
+    var database = conf.getString("output.db.database")
+    var schema = conf.getString("output.db.schema")
+    val username = conf.getString("output.db.username")
+    val password = conf.getString("output.db.password")
+
+     if (schema.length() > 0) { 
+        database = database.concat("?currentSchema=")
+        database = database.concat(schema)
+     }
+
+    logger.debug(s"database $database")
+
+    Class.forName("org.postgresql.Driver")
+    DriverManager.getConnection(
+      s"jdbc:postgresql://$hostname:$port/$database", username, password)
+
+  }
+
 }


### PR DESCRIPTION
Added ability to configure a tenant schema on the database connection string, plus the ability to fetch the FHIR resource JSON schema from the StructureDefinition table.

Note: this latter not as useful as I thought it was going to be because the schema definition in the FHIR database is at a more summary level than the CareConnect schema file, so less fields than you would expect get exposed in the views.